### PR TITLE
squidguardmgr.js pick_redirects patch

### DIFF
--- a/htdocs/squidguardmgr.js
+++ b/htdocs/squidguardmgr.js
@@ -163,3 +163,16 @@ function conditional_status (idx)
 		}
 	}
 }
+
+function pick_redirect ()
+{
+	var str = '';
+	var radioList = document.forms[0].redirect;
+	for (var i=0; i<radioList.length; i++) {
+		if (radioList[i].checked) {
+			str = radioList[i].value;
+			break;
+		}
+	}
+	return str;
+}


### PR DESCRIPTION
Required by squidguardmgr.cgi pick_redirects function. This enables the popup window to update window.opener's form value.
