### PR TITLE
Exclude archived logs from log listing

### DIFF
--- a/cgi-bin/squidguardmgr.cgi
+++ b/cgi-bin/squidguardmgr.cgi
@@ -3400,7 +3400,7 @@ sub show_logs
 		$ERROR = "can't opendir $CONFIG->{logdir}: $!";
 		return;
 	}
-	my @files = grep { !/^\./ && -f "$CONFIG->{logdir}/$_" } readdir(DIR);
+	my @files = grep { !/^\./ && !/\.(gz|tgz|bz2|zip)$/ && -f "$CONFIG->{logdir}/$_" } readdir(DIR);
 	print "<table >\n";
 	print "<tr><td colspan=\"2\">", &show_help('logs'), "</td></tr>\n";
 	if ($#files == -1) {


### PR DESCRIPTION
Logrotate saves old log file with gunzip per EPEL squidGuard RPM default. It's better to prevent binary files from being clicked upon by unskilled administrators. You could be working for the source-ordering, I leave this uncommitted. Pull it yourself at your convenience :-)
